### PR TITLE
[Autofix][warning] Alert #44: Poorly documented large function

### DIFF
--- a/XEngine_Source/XEngine_MQServiceApp/XEngine_MQServiceApp.cpp
+++ b/XEngine_Source/XEngine_MQServiceApp/XEngine_MQServiceApp.cpp
@@ -122,14 +122,23 @@ LONG WINAPI Coredump_ExceptionFilter(EXCEPTION_POINTERS* pExceptionPointers)
 }
 #endif
 
+// Application entry point.
+// Responsibilities:
+// 1) Perform platform-specific runtime initialization.
+// 2) Initialize service components (logging/network/protocol workers).
+// 3) Start and monitor the service lifecycle until shutdown.
+// 4) Release resources in reverse order on exit paths.
 int main(int argc, char** argv)
 {
 #ifdef _WINDOWS
+	// Windows-only socket runtime initialization.
 	WSADATA st_WSAData;
 	WSAStartup(MAKEWORD(2, 2), &st_WSAData);
 
+	// Register crash handler to generate minidump for post-mortem analysis.
 	SetUnhandledExceptionFilter(Coredump_ExceptionFilter);
 #ifndef _DEBUG
+	// Force UTF-8 locale in non-debug mode to keep runtime text handling consistent.
 	if (setlocale(LC_ALL, ".UTF8") == NULL)
 	{
 		fprintf(stderr, "Error setting locale.\n");


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#44](https://github.com/libxengine/XEngine_MQService/security/code-scanning/44) |
| **安全级别** | warning |
| **规则名称** | Poorly documented large function |
| **问题文件** | `XEngine_Source/XEngine_MQServiceApp/XEngine_MQServiceApp.cpp` 第 125 行 |
| **CWE 分类** |  |
| **规则标签** | documentation, maintainability, non-attributable, statistical |

---

### 🔍 问题说明

# Poorly documented large function
This rule finds large functions that have too few comment lines. Documentation becomes more important as a function becomes more complex, and a lack of documentation makes it harder to maintain.


## Recommendation
Add comments to document the purpose of the function. Large, complex functions in particular require detailed documentation, not only because they are harder to understand, but the process of documentation may reveal that the function could be split into smaller, more cohesive functions.


## References
* [C++ Programming, Coding style conventions](http://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments)
* [Wikipedia: Need for comments](http://en.wikipedia.org/wiki/Comment_%28computer_progr

---

### 🤖 AI 修复思路

To fix this without changing functionality, add concise, structured comments inside `main` that document:
- the overall purpose of the entry point,
- major execution phases (platform init, config/arg parsing, component startup, run loop, shutdown),
- platform-specific branches and why they exist,
- critical error-handling/early-return paths.

Best approach: annotate existing logical blocks rather than adding verbose line-by-line comments. This improves maintainability and satisfies the comment-density rule while keeping behavior identical.

In `XEngine_Source/XEngine_MQServiceApp/XEngine_MQServiceApp.cpp`, update the `main` function region (starting at line 125 shown) by:
1. adding a short function-level comment block immediately above `int main(...)`,
2. adding section comments before major preprocessor/platform blocks and startup/shutdown phases already present in `main`.

No imports, new methods, or new dependencies are required.

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。